### PR TITLE
Add configurable delay for IPC operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ This will compile the source files from the `/src` directory and place the execu
 
 ## 📘 How to Play
 
-After compiling, run the executable to access the terminal menu:
+After compiling, run the executable to access the terminal menu. You may optionally specify the delay (in seconds) as the first argument:
 
-./build/processes-n-pipes
+./build/processes-n-pipes [delay]
 
 
 Follow the on-screen prompts to choose between various IPC demonstrations. When prompted, enter a message or a number based on your selection. Explore different functionalities and observe the impact of communication delays firsthand.
@@ -58,7 +58,7 @@ This version introduces a terminal menu that allows users to select between diff
 - **Palindrome and Return a Message**: Creates a palindrome from the input string.
 - **Perform a Random Math Operation on a Number**: Executes a random math operation on a provided number.
 
-Additionally, the introduction of a 3-second delay between parent and child communications offers insights into how processes interact with timing considerations.
+Additionally, communications are delayed by default to better highlight process interaction. You can override the default 3‑second pause by providing a delay value on the command line when starting the program.
 
 ## 💡 Contribute & Learn
 

--- a/include/utilities.h
+++ b/include/utilities.h
@@ -26,6 +26,12 @@
 #define COLOR_WHITE "\x1b[37m"
 #define COLOR_YELLOW "\x1b[33m"
 
+// Default delay in seconds used for parent/child communication
+#define DEFAULT_DELAY 3
+
+// Global variable holding the actual delay duration
+extern int delaySeconds;
+
 // Function declarations
 char *toggleString(const char *input);
 int inputValidation(int argc, char *argv[]);

--- a/src/child.c
+++ b/src/child.c
@@ -9,7 +9,7 @@ void childProcess(int fd[], int choice)
     {
         // Handling a random math operation
         int number;
-        sleep(3);
+        sleep(delaySeconds);
         read(fd[CHILD_READ], &number, sizeof(number));
         srand(time(NULL)); // Seed the random number generator
 
@@ -35,7 +35,7 @@ void childProcess(int fd[], int choice)
         }
 
         // Send the result back to the parent
-        sleep(3);
+        sleep(delaySeconds);
         write(fd[CHILD_WRITE], &number, sizeof(number));
         printf(COLOR_CYAN "Child smiles: " COLOR_RESET "All done with the numbers! Sending back a surprise!\n");
     }
@@ -43,7 +43,7 @@ void childProcess(int fd[], int choice)
     {
         // First, read the operation code
         int opCode;
-        sleep(3);
+        sleep(delaySeconds);
         read(fd[CHILD_READ], &opCode, sizeof(opCode));
 
         char buffer[1024];
@@ -79,7 +79,7 @@ void childProcess(int fd[], int choice)
 
         // Cheerfully sending the modified message back
         printf(COLOR_CYAN "Child beams: " COLOR_RESET "Done! Sending it back now!\n");
-        sleep(3);
+        sleep(delaySeconds);
         write(fd[CHILD_WRITE], modifiedMessage, strlen(modifiedMessage) + 1);
 
         free(modifiedMessage); // Free the dynamically allocated memory

--- a/src/main.c
+++ b/src/main.c
@@ -1,9 +1,26 @@
 #include "utilities.h"
 
-int main()
+// Global variable definition for delay duration
+int delaySeconds = DEFAULT_DELAY;
+
+int main(int argc, char *argv[])
 {
     int choice;
     char message[1024];
+
+    // Allow optional command line argument to set the delay
+    if (argc >= 2)
+    {
+        int val = atoi(argv[1]);
+        if (val >= 0)
+        {
+            delaySeconds = val;
+        }
+        else
+        {
+            fprintf(stderr, "Invalid delay specified. Using default of %d seconds.\n", DEFAULT_DELAY);
+        }
+    }
 
     do
     {

--- a/src/parent.c
+++ b/src/parent.c
@@ -29,7 +29,7 @@ void parentProcess(int fd[], char *message, int choice)
         printf(COLOR_GREEN "Parent is confused: " COLOR_RESET "Hmm, not sure what you want, but let's try '" COLOR_WHITE "%s" COLOR_RESET "' anyway.\n", message);
         break;
     }
-    sleep(3);
+    sleep(delaySeconds);
 
     // Send the operation code to the child
     fprintf(stderr, COLOR_WHITE "Parent: " COLOR_RESET "Sending Message to Child Process...\n");
@@ -43,7 +43,7 @@ void parentProcess(int fd[], char *message, int choice)
     if (choice != 4)
     {
         // Send the message for string operations
-        sleep(3);
+        sleep(delaySeconds);
         if (write(fd[PARENT_WRITE], message, strlen(message) + 1) != strlen(message) + 1)
         {
             fprintf(stderr, COLOR_WHITE "Parent sighs: " COLOR_RESET "Oopsie daisy, my message got lost in the mail...\n");
@@ -55,7 +55,7 @@ void parentProcess(int fd[], char *message, int choice)
     if (choice == 4)
     {
         int result;
-        sleep(3);
+        sleep(delaySeconds);
         if (read(fd[PARENT_READ], &result, sizeof(result)) < 0)
         {
             fprintf(stderr, COLOR_WHITE "Parent frets: " COLOR_RESET "Gosh, I never heard back. Are they ignoring me?\n");
@@ -66,7 +66,7 @@ void parentProcess(int fd[], char *message, int choice)
     else
     {
         char buffer[1024];
-        sleep(3);
+        sleep(delaySeconds);
         int length = read(fd[PARENT_READ], buffer, sizeof(buffer));
         if (length < 0)
         {


### PR DESCRIPTION
## Summary
- add `DEFAULT_DELAY` and global `delaySeconds`
- allow setting delay via command line argument
- replace hard-coded `sleep(3)` calls with `delaySeconds`
- document optional delay argument in README

## Testing
- `make clean && make`
- `./build/processes-n-pipes 1 <<'EOF'
5
EOF`

------
https://chatgpt.com/codex/tasks/task_b_684376da319483249bfc8dd5006985da