### PR TITLE
Use strtol for delay argument validation

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -11,14 +11,16 @@ int main(int argc, char *argv[])
     // Allow optional command line argument to set the delay
     if (argc >= 2)
     {
-        int val = atoi(argv[1]);
-        if (val >= 0)
+        char *endptr = NULL;
+        long val = strtol(argv[1], &endptr, 10);
+
+        if (*argv[1] != '\0' && *endptr == '\0' && val >= 0)
         {
-            delaySeconds = val;
+            delaySeconds = (int)val;
         }
         else
         {
-            fprintf(stderr, "Invalid delay specified. Using default of %d seconds.\n", DEFAULT_DELAY);
+            fprintf(stderr, "Invalid numeric delay. Using default of %d seconds.\n", DEFAULT_DELAY);
         }
     }
 


### PR DESCRIPTION
## Summary
- improve parsing of delay argument by replacing `atoi` with `strtol`
- verify the argument is numeric and non‑negative

## Testing
- `make clean && make`
- `./build/processes-n-pipes -1 <<EOF
5
EOF`
- `./build/processes-n-pipes 4 <<EOF
5
EOF`

------
https://chatgpt.com/codex/tasks/task_b_68438c230ba8832487056bf45726af34