### PR TITLE
Remove unused inputValidation function

### DIFF
--- a/include/utilities.h
+++ b/include/utilities.h
@@ -34,7 +34,6 @@ extern int delaySeconds;
 
 // Function declarations
 char *toggleString(const char *input);
-int inputValidation(int argc, char *argv[]);
 
 void childProcess(int fd[], int choice);
 void parentProcess(int fd[], char *message, int choice);

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -18,26 +18,6 @@ char *toggleString(const char *input)
     return toggledStr;
 }
 
-int inputValidation(int argc, char *argv[])
-{
-    if (argc != 2)
-    {
-        fprintf(stderr, "Usage: %s <'Your string here'>\n", argv[0]);
-        return EXIT_FAILURE;
-    }
-
-    for (int i = 0; argv[1][i] != '\0'; ++i)
-    {
-        if (isalpha(argv[1][i]))
-        {
-            return 0;
-        }
-    }
-
-    printf("The string you entered does not contain any alphabetical characters.\n");
-    printf("Please run the program again with at least one alphabetical character.\n");
-    return EXIT_FAILURE;
-}
 
 char *createPalindrome(const char *word)
 {


### PR DESCRIPTION
## Summary
- clean up utilities by dropping the unused `inputValidation` prototype and function

## Testing
- `make clean`
- `make`


------
https://chatgpt.com/codex/tasks/task_b_6843918e904c8324bf95770c572a8465