### PR TITLE
Implement improvements and add integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SRCDIR = src
 BUILDDIR = build
 OBJDIR = $(BUILDDIR)/object
 
-.PHONY: build $(OBJDIR)
+.PHONY: build $(OBJDIR) clean
 
 # Define the C source files (wildcard picks all .c files in the directory)
 SOURCES = $(wildcard $(SRCDIR)/*.c)
@@ -39,11 +39,14 @@ $(OBJDIR)/%.o: $(SRCDIR)/%.c | $(OBJDIR)
 
 clean:
 	rm -f $(OBJDIR)/*.o $(TARGET)
-
 tests/test_operations: tests/test_operations.c src/utilities.c | build
 	$(CC) $(CFLAGS) -o $@ $^
 
+tests/test_menu: tests/test_menu.c | build $(TARGET)
+	$(CC) $(CFLAGS) -o $@ tests/test_menu.c
+
 .PHONY: test
 
-test: tests/test_operations
+test: $(TARGET) tests/test_operations tests/test_menu
 	./tests/test_operations
+	./tests/test_menu

--- a/include/utilities.h
+++ b/include/utilities.h
@@ -63,6 +63,15 @@ ssize_t robustRead(int fd, void *buf, size_t count);
  */
 ssize_t robustWrite(int fd, const void *buf, size_t count);
 
+/** Operation codes sent between the parent and child processes. */
+typedef enum
+{
+    OP_TOGGLE = 1,
+    OP_UPPERCASE,
+    OP_PALINDROME,
+    OP_RANDOM_MATH
+} Operation;
+
 // Function declarations
 /**
  * Toggle the case of every character in the input string.
@@ -71,9 +80,9 @@ ssize_t robustWrite(int fd, const void *buf, size_t count);
 char *toggleString(const char *input);
 
 /** Handle the child side of IPC based on the user's menu choice. */
-void childProcess(int fd[], int choice);
+void childProcess(int fd[], Operation choice);
 /** Handle the parent side of IPC based on the user's menu choice. */
-void parentProcess(int fd[], char *message, int choice);
+void parentProcess(int fd[], char *message, Operation choice);
 
 /**
  * Build a palindrome using the provided word.
@@ -90,7 +99,5 @@ char *uppercaseOperation(const char *input);
  * Perform a random math operation on the given number and return the result.
  */
 int randomMathOperation(int number);
-
-typedef char *(*StringOperation)(const char *input);
 
 #endif

--- a/src/child.c
+++ b/src/child.c
@@ -1,11 +1,11 @@
 #include "utilities.h"
 
-void childProcess(int fd[], int choice)
+void childProcess(int fd[], Operation choice)
 {
     // Close unused ends of the pipes
     MY_CLOSE(fd[PARENT_READ]);
     MY_CLOSE(fd[PARENT_WRITE]);
-    if (choice == 4)
+    if (choice == OP_RANDOM_MATH)
     {
         // Handling a random math operation
         int number;
@@ -27,7 +27,7 @@ void childProcess(int fd[], int choice)
     else
     {
         // First, read the operation code
-        int opCode;
+        Operation opCode;
         MY_SLEEP(delaySeconds);
         if (robustRead(fd[CHILD_READ], &opCode, sizeof(opCode)) < 0)
             exit(EXIT_FAILURE);
@@ -42,15 +42,15 @@ void childProcess(int fd[], int choice)
         // Enthusiastically accepting the task
         switch (opCode)
         {
-        case 1: // Toggle case
+        case OP_TOGGLE:
             printf(COLOR_CYAN "Child giggles: " COLOR_RESET "Oh, I love playing with case! Watch this!\n");
             modifiedMessage = toggleString(buffer);
             break;
-        case 2: // Uppercase
+        case OP_UPPERCASE:
             printf(COLOR_CYAN "Child shouts: " COLOR_RESET "I'll shout this back, louder and prouder!\n");
             modifiedMessage = uppercaseOperation(buffer);
             break;
-        case 3: // Create Palindrome
+        case OP_PALINDROME:
             printf(COLOR_CYAN "Child muses: " COLOR_RESET "Mirroring is fun, let's make a palindrome!\n");
             modifiedMessage = createPalindrome(buffer);
             break;

--- a/src/main.c
+++ b/src/main.c
@@ -83,24 +83,27 @@ int main(int argc, char *argv[])
 
         if (pid == 0)
         {
-            childProcess(fd, choice);
+            childProcess(fd, (Operation)choice);
             exit(0);
         }
         else
         {
-            if (choice == 4)
+            if (choice == OP_RANDOM_MATH)
             {
                 int number;
                 printf(COLOR_GREEN "Parent asks: " COLOR_RESET "Enter a number: ");
                 scanf("%d", &number);
-                parentProcess(fd, (char *)&number, choice);
+                int c;
+                while ((c = getchar()) != '\n' && c != EOF)
+                    ;
+                parentProcess(fd, (char *)&number, (Operation)choice);
             }
             else
             {
                 printf(COLOR_GREEN "Parent asks: " COLOR_RESET "Enter your message: ");
                 fgets(message, sizeof(message), stdin);
                 message[strcspn(message, "\n")] = 0;
-                parentProcess(fd, message, choice);
+                parentProcess(fd, message, (Operation)choice);
             }
             wait(NULL);
         }

--- a/src/parent.c
+++ b/src/parent.c
@@ -1,6 +1,6 @@
 #include "utilities.h"
 
-void parentProcess(int fd[], char *message, int choice)
+void parentProcess(int fd[], char *message, Operation choice)
 {
     // Close unused ends of the pipes
     MY_CLOSE(fd[CHILD_READ]);
@@ -9,16 +9,16 @@ void parentProcess(int fd[], char *message, int choice)
     // A playful message for sending the operation to the child
     switch (choice)
     {
-    case 1:
+    case OP_TOGGLE:
         printf(COLOR_GREEN "Parent whispers: " COLOR_RESET "Hey Kiddo, can you " COLOR_YELLOW "toggle" COLOR_RESET " this for me? --> '" COLOR_WHITE "%s" COLOR_RESET "'\n", message);
         break;
-    case 2:
+    case OP_UPPERCASE:
         printf(COLOR_GREEN "Parent muses: " COLOR_RESET "Hey Kiddo, could you please " COLOR_YELLOW "shout" COLOR_RESET " this out loud? --> '" COLOR_WHITE "%s" COLOR_RESET "'\n", message);
         break;
-    case 3:
+    case OP_PALINDROME:
         printf(COLOR_GREEN "Parent ponders: " COLOR_RESET "Oh, what if we made this " COLOR_YELLOW "mirror" COLOR_RESET " itself? --> '" COLOR_WHITE "%s" COLOR_RESET "'\n", message);
         break;
-    case 4:
+    case OP_RANDOM_MATH:
         // Correctly interpret the message as a pointer to an integer
         int *pNumber = (int *)message;
         printf(COLOR_GREEN "Parent quizzes: " COLOR_RESET "I wonder how we can play with the number " COLOR_YELLOW "%d" COLOR_RESET " today?\n", *pNumber);
@@ -41,7 +41,7 @@ void parentProcess(int fd[], char *message, int choice)
         exit(EXIT_FAILURE);
     }
 
-    if (choice != 4)
+    if (choice != OP_RANDOM_MATH)
     {
         // Send the message for string operations
         MY_SLEEP(delaySeconds);
@@ -53,7 +53,7 @@ void parentProcess(int fd[], char *message, int choice)
     }
 
     // Wait for and display the modified message or result from the child
-    if (choice == 4)
+    if (choice == OP_RANDOM_MATH)
     {
         int result;
         MY_SLEEP(delaySeconds);

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -24,18 +24,19 @@ ssize_t robustWrite(int fd, const void *buf, size_t count)
 
 char *toggleString(const char *input)
 {
-    char *toggledStr = malloc(strlen(input) + 1);
+    size_t len = strlen(input);
+    char *toggledStr = malloc(len + 1);
     if (!toggledStr)
     {
         perror("Allocation failed");
         exit(EXIT_FAILURE);
     }
 
-    for (int i = 0; input[i] != '\0'; ++i)
+    for (size_t i = 0; i < len; ++i)
     {
-        toggledStr[i] = islower(input[i]) ? toupper(input[i]) : tolower(input[i]);
+        toggledStr[i] = islower((unsigned char)input[i]) ? toupper((unsigned char)input[i]) : tolower((unsigned char)input[i]);
     }
-    toggledStr[strlen(input)] = '\0';
+    toggledStr[len] = '\0';
 
     return toggledStr;
 }
@@ -72,19 +73,20 @@ char *uppercaseOperation(const char *input)
     if (input == NULL)
         return NULL;
 
-    char *output = malloc(strlen(input) + 1);
+    size_t len = strlen(input);
+    char *output = malloc(len + 1);
     if (!output)
     {
         perror("Allocation failed");
         exit(EXIT_FAILURE);
     }
 
-    for (int i = 0; input[i] != '\0'; ++i)
+    for (size_t i = 0; i < len; ++i)
     {
-        output[i] = toupper(input[i]);
+        output[i] = toupper((unsigned char)input[i]);
     }
 
-    output[strlen(input)] = '\0';
+    output[len] = '\0';
 
     return output;
 }

--- a/tests/test_menu.c
+++ b/tests/test_menu.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+int main(void)
+{
+    FILE *fp = popen("printf '2\nHello\n5\n' | ./build/processes-n-pipes", "r");
+    if (!fp)
+    {
+        perror("popen");
+        return 1;
+    }
+
+    char buffer[2048];
+    size_t len = fread(buffer, 1, sizeof(buffer) - 1, fp);
+    buffer[len] = '\0';
+    pclose(fp);
+
+    if (strstr(buffer, "HELLO") == NULL)
+    {
+        fprintf(stderr, "Uppercase result not found in output\n");
+        return 1;
+    }
+
+    printf("Menu test passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `Operation` enum for menu codes
- flush newline after number entry in `main`
- store string length once in `toggleString` and `uppercaseOperation`
- mark `clean` target as phony and compile new integration test
- add basic menu interaction test

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_684394ab5c108324ba910379ee0359f7